### PR TITLE
fix #213

### DIFF
--- a/src/jsonUtils/hacksForJSONImpl.js
+++ b/src/jsonUtils/hacksForJSONImpl.js
@@ -270,8 +270,10 @@ export function makeEncodedAttributedString(textNodes: TextNodes) {
     fullStr.appendAttributedString(newString);
   });
 
-  const msAttribStr = MSAttributedString.alloc().initWithAttributedString(
-    fullStr
+  const encodedAttribStr = MSAttributedString.encodeAttributedString(fullStr);
+
+  const msAttribStr = MSAttributedString.alloc().initWithEncodedAttributedString(
+    encodedAttribStr
   );
 
   return encodeSketchJSON(msAttribStr);


### PR DESCRIPTION
`initWithAttributedString` is undefined in version 48.
I used `initWithEncodedAttributedString` instead of `initWithAttributedString`.